### PR TITLE
[FEATURE-6] Allow specifying DRAGONS branch and location

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
     - uses: excitedleigh/setup-nox@v2.1.0
 
       name: ${{ matrix.python }}
-    - run: nox -s test -p ${{ matrix.python }}
+    - run: nox -s test -p ${{ matrix.python }} -n 4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
     - uses: excitedleigh/setup-nox@v2.1.0
 
       name: ${{ matrix.python }}
-    - run: nox -s test -p ${{ matrix.python }} -n 4
+    - run: nox -s test -p ${{ matrix.python }} -- -vv -n 4

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,5 +6,7 @@
   "instrument_fits_name": "{{ cookiecutter.instrument_name.upper() }}",
   "project_slug": "{{ cookiecutter.instrument_name_lower }}_dr_package",
   "primary_author": "DEFAULT_AUTHOR_NAME",
-  "primary_author_email": "DEFAULT_AUTHOR_EMAIL"
+  "primary_author_email": "DEFAULT_AUTHOR_EMAIL",
+  "dragons_branch": "master",
+  "dragons_location": "DRAGONS/"
 }

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,7 +39,7 @@ def initialize_commit_hooks(session: nox.Session):
 @nox.session(python=["3.10", "3.11", "3.12"])
 def test(session: nox.Session):
     """Test the cookiecutter template."""
-    session.install("pytest", "pytest-cookies")
+    session.install("pytest", "pytest-cookies", "nox")
 
     session.run("pytest", "tests/", *session.posargs)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,7 +39,7 @@ def initialize_commit_hooks(session: nox.Session):
 @nox.session(python=["3.10", "3.11", "3.12"])
 def test(session: nox.Session):
     """Test the cookiecutter template."""
-    session.install("pytest", "pytest-cookies", "nox")
+    session.install("pytest", "pytest-cookies", "pytest-xdist", "nox")
 
     session.run("pytest", "tests/", *session.posargs)
 
@@ -117,7 +117,7 @@ def test_filled_template(session: nox.Session):
         session.log(80 * "=")
 
         # Run the tests.
-        session.run("nox", "-s", "tests", "--verbose")
+        session.run("nox", "-s", "tests")
 
 
 @nox.session()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -174,7 +174,7 @@ def test_download_correct_dragons_version(dragons_branch, cookies, monkeypatch):
     output = result.stdout.decode("utf-8")
 
     for line in output.splitlines():
-        if match := re.match(r"^\s+*\s+([A-Za-z0-9-/_]+)\s*$", line):
+        if match := re.match(r"^\s+\*\s+([A-Za-z0-9\-/_]+)\s*$", line):
             assert match.group(1) == dragons_branch
             break
 

--- a/{{ cookiecutter.project_slug }}/noxfile.py
+++ b/{{ cookiecutter.project_slug }}/noxfile.py
@@ -23,8 +23,8 @@ DRAGONS_URL = R"https://github.com/GeminiDRSoftware/DRAGONS"
 CALMGR_URL = R"https://github.com/GeminiDRSoftware/GeminiCalMgr.git@release/1.1.x"
 OBSDB_URL = R"https://github.com/GeminiDRSoftware/GeminiObsDB.git@release/1.0.x"
 
-DRAGONS_BRANCH = "master"
-DRAGONS_LOCATION = "DRAGONS/"
+DRAGONS_BRANCH = "{{ cookiecutter.dragons_branch }}"
+DRAGONS_LOCATION = "{{ cookiecutter.dragons_location }}"
 
 
 def check_dragons_version(session: nox.Session):


### PR DESCRIPTION
# Summary

The DRAGONS branch and location can be specified in the following ways, now:

- [x] By changing the default (for the generated repo) in `noxfile.py` for post-generation changes
- [x] By answering a question in the `cookiecutter` prompt
  + Added a new entry to `cookiecutter.json`
- [x] By setting environment variables (`DRAGONS_BRANCH` and `DRAGONS_LOCATION`, respectively).
